### PR TITLE
Replace rand with fastrand

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5,3 +5,30 @@ version = 3
 [[package]]
 name = "bitches"
 version = "0.1.0"
+dependencies = [
+ "fastrand",
+]
+
+[[package]]
+name = "cfg-if"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "baf1de4339761588bc0619e3cbc0120ee582ebb74b53b4efbf79117bd2da40fd"
+
+[[package]]
+name = "fastrand"
+version = "1.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c3fcf0cee53519c866c09b5de1f6c56ff9d647101f81c1964fa632e148896cdf"
+dependencies = [
+ "instant",
+]
+
+[[package]]
+name = "instant"
+version = "0.1.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7a5bbe824c507c5da5956355e86a746d82e0e1464f65d862cc5e71da70e94b2c"
+dependencies = [
+ "cfg-if",
+]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,4 +15,4 @@ repository = "https://github.com/AradiaIsStupid/bitches"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-rand = "0.8.5"
+fastrand = "1.7.0"

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,5 +1,3 @@
-use rand::seq::SliceRandom;
-
 const ART: [&str; 3] = ["
 ======= NO Bitches ? =======
 ⠀⣞⢽⢪⢣⢣⢣⢫⡺⡵⣝⡮⣗⢷⢽⢽⢽⣮⡷⡽⣜⣜⢮⢺⣜⢷⢽⢝⡽⣝
@@ -58,6 +56,6 @@ const ART: [&str; 3] = ["
 ];
 
 fn main() {
-    let art = ART.choose(&mut rand::thread_rng()).unwrap();
+    let art = ART[fastrand::usize(..ART.len())];
     art.chars().for_each(|c| print!("{}", c));
 }


### PR DESCRIPTION
`rand` is a fairly heavy dependency. On the other hand, `fastrand` is pretty lightweight and has zero dependencies.

